### PR TITLE
input_component_done

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -121,6 +121,10 @@
   }
 }
 
+input:focus::placeholder {
+  opacity: 0;
+}
+
 @theme {
   /* Neutral colors */
   --color-neutrals-white: #ffffff;

--- a/src/components/ui/Input.stories.tsx
+++ b/src/components/ui/Input.stories.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Input } from "./input";
+import { Search } from "lucide-react";
+
+const meta: Meta<typeof Input> = {
+  component: Input,
+  title: "UI/Input",
+  tags: ["autodocs"],
+};
+export default meta;
+
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {
+  args: {
+    placeholder: "Type something...",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    placeholder: "Disabled input",
+    disabled: true,
+  },
+};
+
+export const WithValue: Story = {
+  args: {
+    value: "Hello world",
+    readOnly: true,
+  },
+};
+
+export const WithIcons: Story = {
+  render: (args) => {
+    const [value, setValue] = React.useState("");
+    return (
+      <Input
+        {...args}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        startIcon={<Search size={16} />}
+        endComponent={
+          value ? (
+            <button onClick={() => setValue("")}>
+              <svg width="16" height="16" fill="none" viewBox="0 0 16 16">
+                <path
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4 4l8 8M12 4l-8 8"
+                />
+              </svg>
+            </button>
+          ) : null
+        }
+        placeholder="With start and end icons"
+      />
+    );
+  },
+};

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+const customInputStyles =
+  "font-[var(--font-family-mulish)] focus:border-[2px] focus:border-[var(--color-primary-400)] hover:border-[2px] hover:border-[var(--color-primary-400)] custom-input active:shadow-none";
+
+type InputProps = React.ComponentProps<"input"> & {
+  startIcon?: React.ReactNode;
+  endComponent?: React.ReactNode;
+};
+
+function Input({
+  className,
+  type = "text",
+  startIcon,
+  endComponent,
+  ...props
+}: InputProps) {
+  return (
+    <div className="relative w-full flex items-center">
+      {startIcon && (
+        <span className="absolute left-2 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">
+          {startIcon}
+        </span>
+      )}
+      <input
+        type={type}
+        data-slot="input"
+        className={cn(
+          startIcon ? "pl-8" : "pl-3",
+          endComponent ? "pr-8" : "pr-3",
+          "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+          "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+          customInputStyles,
+          className
+        )}
+        {...props}
+      />
+      {endComponent && (
+        <span className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center">
+          {endComponent}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export { Input };


### PR DESCRIPTION
Add Customizable Input Component
Created a reusable component with:
Support for a prop to render an icon on the left side of the input
Support for an prop to render any component (such as a clear button) on the right side of the input
Custom font and border styles using Tailwind and CSS variables
